### PR TITLE
Load environment variables as dotenv options

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,5 +1,21 @@
+var envOptions = [
+    // from dotenv
+    ['DOTENV_CONFIG_ENCODING', 'encoding'],
+    ['DOTENV_CONFIG_PATH', 'path'],
+    ['DOTENV_CONFIG_DEBUG', 'debug'],
+    ['DOTENV_CONFIG_OVERRIDE', 'override'],
+    // added for dotenv-safer
+    ['DOTENV_CONFIG_EXAMPLE', 'example'],
+    ['DOTENV_CONFIG_ALLOW_EMPTY_VALUES', 'allowEmptyValues']
+];
+
 (function () {
     var options = {};
+    envOptions.forEach(function (pair) {
+        if (process.env[pair[0]] != null) {
+            options[pair[1]] = process.env[pair[0]];
+        }
+    });
     process.argv.forEach(function (val) {
         var matches = val.match(/^dotenv_config_(.+)=(.+)/);
         if (matches) {


### PR DESCRIPTION
This PR adds loading of environment variables of the form `DOTENV_CONFIG_*` as options when using the `dotenv-safer/config` import path.

This mimics the same functionality of `dotenv` that has always been missing from `dotenv-safe` (and `dotenv-safer`), adding the two configuration options that are specific for this package: `DOTENV_CONFIG_EXAMPLE` and `DOTENV_CONFIG_ALLOW_EMPTY_VALUES`.

I did not add any tests because there doesn't seem to be any for the `dotenv-safer/config` import specifically.